### PR TITLE
chore: run contract tests as a github action

### DIFF
--- a/.github/workflows/env_github_actions
+++ b/.github/workflows/env_github_actions
@@ -1,2 +1,2 @@
-RPC_URL=https://polygon-rpc.com
+POLYGON_RPC_URL=https://polygon-rpc.com
 MNEMONIC=oblige wall cloth way desk between country enact chair civil auto beauty

--- a/.github/workflows/env_github_actions
+++ b/.github/workflows/env_github_actions
@@ -1,1 +1,2 @@
+POLYGON_RPC_URL=https://polygon-rpc.com
 MNEMONIC=oblige wall cloth way desk between country enact chair civil auto beauty

--- a/.github/workflows/env_github_actions
+++ b/.github/workflows/env_github_actions
@@ -1,0 +1,1 @@
+MNEMONIC=oblige wall cloth way desk between country enact chair civil auto beauty

--- a/.github/workflows/env_github_actions
+++ b/.github/workflows/env_github_actions
@@ -1,2 +1,2 @@
-POLYGON_RPC_URL=https://polygon-rpc.com
+RPC_URL=https://polygon-rpc.com
 MNEMONIC=oblige wall cloth way desk between country enact chair civil auto beauty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 
 name: hardhat test
 
-on: [push, pull_request]
+on: [push, fork]
 
 jobs:
   build:
@@ -39,18 +39,5 @@ jobs:
     - name: Run tests using the fork specified by hardhat.config.js
       run: npx hardhat test
 
-    - name: Get the latest block on Polygon mainnet and specify RPC as env var
-      run: |
-        echo RPC_URL=https://polygon-rpc.com >> $GITHUB_ENV 
-        echo LATEST_BLOCK_NUMBER=`curl https://polygon-rpc.com -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV        
-
-    - name: Set the block number to fork from
-      # Use a slightly older block with 64 confirmations
-      run: echo RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40)) >> $GITHUB_ENV
-
     - name: Run tests on a fork from a very recent block
-      run: |
-        echo "Forking from block number ${RECENT_BLOCK_NUMBER}"
-        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER > /dev/null &
-        sleep 2
-        npx hardhat test --network localhost
+      run: ./bin/test_recent_fork.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,13 @@ jobs:
     - name: Run tests using the fork specified by hardhat.config.js
       run: npx hardhat test
 
-    - name: Run tests on a fork from a very recent block
+    - name: Get the latest block on Polygon mainnet and specify env vars
       run: |
         echo RPC_URL=https://polygon-rpc.com >> $GITHUB_ENV 
-        echo LATEST_BLOCK_NUMBER=`curl $RPC_URL -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV
+        echo LATEST_BLOCK_NUMBER=`curl https://polygon-rpc.com -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV
+
+    - name: Run tests on a fork from a very recent block
+      run: |
         # Use a slightly older block with 32 confirmations
-        npx hardhat node --fork $RPC_URL --fork-block-number $(($LATEST_BLOCK_NUMBER - 0x40)) > /dev/null &
+        npx hardhat node --fork $RPC_URL --fork-block-number $(($LATEST_BLOCK_NUMBER - 0x20)) > /dev/null &
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Run tests using the fork specified by hardhat.config.js
       run: npx hardhat test
 
-    -name: Run tests on a fork from a very recent block
+    - name: Run tests on a fork from a very recent block
       run:
         RPC_URL=https://polygon-rpc.com
         BLOCK_NUMBER=`curl $RPC_URL -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     environment: hardhat tests
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,15 +39,17 @@ jobs:
     - name: Run tests using the fork specified by hardhat.config.js
       run: npx hardhat test
 
-    - name: Get the latest block on Polygon mainnet and specify env vars
+    - name: Get the latest block on Polygon mainnet and specify RPC as env var
       run: |
         echo RPC_URL=https://polygon-rpc.com >> $GITHUB_ENV 
-        echo LATEST_BLOCK_NUMBER=`curl https://polygon-rpc.com -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV
-        echo RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x20)) >> $GITHUB_ENV
+        echo LATEST_BLOCK_NUMBER=`curl https://polygon-rpc.com -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV        
+
+    - name: Set the block number to fork from
+      # Use a slightly older block with 64 confirmations
+      run: echo RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40)) >> $GITHUB_ENV
 
     - name: Run tests on a fork from a very recent block
       run: |
-        echo "Forking from block number $RECENT_BLOCK_NUMBER"RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40)) 
-        # Use a slightly older block with 64 confirmations
+        echo "Forking from block number ${RECENT_BLOCK_NUMBER}"
         npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER > /dev/null &
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm install
+    - run: cp .github/workflows/env_github_actions .env
     - run: npx hardhat compile
     - run: npx hardhat test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,9 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Node.js CI
+name: hardhat test
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: push
 
 jobs:
   build:
@@ -27,4 +23,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm install
+    - run: npx hardhat compile
     - run: npx hardhat test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
     - name: Run tests on a fork from a very recent block
       run: |
         echo "Forking from block number ${RECENT_BLOCK_NUMBER}"
-        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER > /dev/null &
+        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER &
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
       run: npx hardhat test
 
     - name: Run tests on a fork from a very recent block
-      run:
-        RPC_URL=https://polygon-rpc.com
-        BLOCK_NUMBER=`curl $RPC_URL -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result`
+      run: |
+        echo RPC_URL=https://polygon-rpc.com >> $GITHUB_ENV 
+        echo LATEST_BLOCK_NUMBER=`curl $RPC_URL -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV
         # Use a slightly older block with 32 confirmations
         npx hardhat node --fork $RPC_URL --fork-block-number $(($LATEST_BLOCK_NUMBER - 0x40)) > /dev/null &
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 
 name: hardhat test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,6 @@ jobs:
     - name: Run tests on a fork from a very recent block
       run: |
         echo "Forking from block number ${RECENT_BLOCK_NUMBER}"
-        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER &
+        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER > /dev/null &
+        sleep 2
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,11 @@ jobs:
       run: |
         echo RPC_URL=https://polygon-rpc.com >> $GITHUB_ENV 
         echo LATEST_BLOCK_NUMBER=`curl https://polygon-rpc.com -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result` >> $GITHUB_ENV
+        echo RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x20)) >> $GITHUB_ENV
 
     - name: Run tests on a fork from a very recent block
       run: |
-        # Use a slightly older block with 32 confirmations
-        npx hardhat node --fork $RPC_URL --fork-block-number $(($LATEST_BLOCK_NUMBER - 0x20)) > /dev/null &
+        echo "Forking from block number $RECENT_BLOCK_NUMBER"RECENT_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40)) 
+        # Use a slightly older block with 64 confirmations
+        npx hardhat node --fork $RPC_URL --fork-block-number $RECENT_BLOCK_NUMBER > /dev/null &
         npx hardhat test --network localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,32 @@ jobs:
     environment: hardhat tests
     steps:
     - uses: actions/checkout@v3
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
-    - run: cp .github/workflows/env_github_actions .env
-    - run: npx hardhat compile
-    - run: npx hardhat test
+
+    - name: Install command-line deps
+      run: sudo apt install jq
+
+    - name: Install hardhat/node packages
+      run: npm install
+
+    - name: Create dotenv file
+      run: cp .github/workflows/env_github_actions .env
+
+    - name: Compile contracts
+      run: npx hardhat compile
+
+    - name: Run tests using the fork specified by hardhat.config.js
+      run: npx hardhat test
+
+    -name: Run tests on a fork from a very recent block
+      run:
+        RPC_URL=https://polygon-rpc.com
+        BLOCK_NUMBER=`curl $RPC_URL -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq  -r .result`
+        # Use a slightly older block with 32 confirmations
+        npx hardhat node --fork $RPC_URL --fork-block-number $(($LATEST_BLOCK_NUMBER - 0x40)) > /dev/null &
+        npx hardhat test --network localhost

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Run "hardhat test" using a local node forked from a very recent block.
+# 
+# Run this script from the project's root directory.
+#
+# Any additonal arguments to this script are forwarded as args to "hardhat test", for example:
+# bin/test_recent_fork.sh --grep WETH
+#
+# Requires jq
+# sudo apt install jq
+
+TEST_EXTRA_ARGS=$@
+
+POLYGON_RPC_URL=https://polygon-rpc.com
+
+LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
+    POST -H "Content-Type: application/json" \
+    --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    | jq  -r .result`;
+FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40))
+
+echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
+npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 
+node_pid=$!
+node_exit_code=$?
+
+sleep 2
+
+test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1 | tee /dev/tty`
+test_exit_code=$?
+
+kill $!
+kill $node_pid
+
+if echo "$test_output" | grep -q "Uncaught error outside test suite"; then 
+    echo -e "\n\nUncaught error outside test suite - problem running 'hardhat node'?"; 
+    exit 1;
+else 
+    echo -e "\n\n'hardhat test' completed with exit code $test_exit_code"; 
+    exit $test_exit_code; 
+fi

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -21,7 +21,7 @@ LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
 FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40))
 
 echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
-npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 
+npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $NO_SUCH_ENV_VAR > /dev/null & 
 node_pid=$!
 node_exit_code=$?
 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -18,7 +18,8 @@ LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
     POST -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
     | jq  -r .result`;
-FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0xFFF))
+# Polygon mainnet block time is 2 seconds, use a block from an hour ago.
+FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 1800))
 
 echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
 npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -18,7 +18,7 @@ LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
     POST -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
     | jq  -r .result`;
-FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40))
+FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0xFFF))
 
 echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
 npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -21,7 +21,7 @@ LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
 FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 0x40))
 
 echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
-npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $NO_SUCH_ENV_VAR > /dev/null & 
+npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 
 node_pid=$!
 node_exit_code=$?
 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -27,17 +27,15 @@ node_exit_code=$?
 
 sleep 2
 
-echo "Running in ci: $CI"
 if [[ $CI == "true" ]]; then
-    TERMINAL=/dev/null  # /dev/tty not available in github actins/docker
+    test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1`
+    test_exit_code=$?
+    echo -e "$test_output"
 else
-    TERMINAL=/dev/tty
+    test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1 | tee /dev/tty`
+    test_exit_code=$?
 fi
 
-test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1 | tee $TERMINAL`
-test_exit_code=$?
-
-kill $!
 kill $node_pid
 
 if echo "$test_output" | grep -q "Uncaught error outside test suite"; then 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -28,6 +28,7 @@ node_exit_code=$?
 sleep 2
 
 if [[ $CI == "true" ]]; then
+    echo "Running tests...."
     test_output=`npx hardhat test --network localhost 2>&1`
     test_exit_code=$?
     echo -e "$test_output"

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -22,11 +22,10 @@ LATEST_BLOCK_NUMBER=`curl -s $POLYGON_RPC_URL -X \
 FORK_BLOCK_NUMBER=$(($LATEST_BLOCK_NUMBER - 1800))
 
 echo -e "\nForking from block $FORK_BLOCK_NUMBER...\n"
-npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null & 
+npx hardhat node --fork $POLYGON_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER > /dev/null &
 node_pid=$!
-node_exit_code=$?
 
-sleep 2
+sleep 3
 
 if [[ $CI == "true" ]]; then
     echo "Running tests...."
@@ -38,7 +37,7 @@ else
     test_exit_code=$?
 fi
 
-kill $node_pid
+kill -9 $node_pid
 
 if echo "$test_output" | grep -q "Uncaught error outside test suite"; then 
     echo -e "\n\nUncaught error outside test suite - problem running 'hardhat node'?"; 

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -28,7 +28,7 @@ node_exit_code=$?
 sleep 2
 
 if [[ $CI == "true" ]]; then
-    test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1`
+    test_output=`npx hardhat test --network localhost 2>&1`
     test_exit_code=$?
     echo -e "$test_output"
 else

--- a/bin/test_recent_fork.sh
+++ b/bin/test_recent_fork.sh
@@ -27,7 +27,14 @@ node_exit_code=$?
 
 sleep 2
 
-test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1 | tee /dev/tty`
+echo "Running in ci: $CI"
+if [[ $CI == "true" ]]; then
+    TERMINAL=/dev/null  # /dev/tty not available in github actins/docker
+else
+    TERMINAL=/dev/tty
+fi
+
+test_output=`npx hardhat test --network localhost $TEST_EXTRA_ARGS 2>&1 | tee $TERMINAL`
 test_exit_code=$?
 
 kill $!

--- a/env
+++ b/env
@@ -1,3 +1,3 @@
-RPC_URL=https://polygon-rpc.com
+POLYGON_RPC_URL=https://polygon-rpc.com
 POLYGONSCAN_API_KEY=1234
 MNEMONIC=never ever put anything here copy the file to .env first

--- a/env
+++ b/env
@@ -1,3 +1,3 @@
-POLYGON_RPC_URL=https://polygon-rpc.com
+RPC_URL=https://polygon-rpc.com
 POLYGONSCAN_API_KEY=1234
 MNEMONIC=never ever put anything here copy the file to .env first

--- a/env
+++ b/env
@@ -1,3 +1,3 @@
-ALCHEMY_POLYGON_API_KEY = 1234
-POLYGONSCAN_API_KEY = 1234
-MNEMONIC = never ever put anything here copy the file to .env first
+POLYGON_RPC_URL=https://polygon-rpc.com
+POLYGONSCAN_API_KEY=1234
+MNEMONIC=never ever put anything here copy the file to .env first

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,7 +15,7 @@ module.exports = {
   networks: {
     hardhat: {
       forking: {
-        url: "https://polygon-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_POLYGON_API_KEY,
+        url: process.env.POLYGON_RPC_URL,
         blockNumber: 35713480, // Nov 17th 2022, around 08:58 UTC
       }
     },

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,7 +15,7 @@ module.exports = {
   networks: {
     hardhat: {
       forking: {
-        url: process.env.RPC_URL,
+        url: process.env.POLYGON_RPC_URL,
         blockNumber: 38824166, // https://polygonscan.com/block/38824166 Feb-02-2023 01:30:00 PM +UTC
       }
     },

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,7 +15,7 @@ module.exports = {
   networks: {
     hardhat: {
       forking: {
-        url: process.env.POLYGON_RPC_URL,
+        url: process.env.RPC_URL,
         blockNumber: 38824166, // https://polygonscan.com/block/38824166 Feb-02-2023 01:30:00 PM +UTC
       }
     },

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -16,7 +16,7 @@ module.exports = {
     hardhat: {
       forking: {
         url: process.env.POLYGON_RPC_URL,
-        blockNumber: 35713480, // Nov 17th 2022, around 08:58 UTC
+        blockNumber: 38824166, // https://polygonscan.com/block/38824166 Feb-02-2023 01:30:00 PM +UTC
       }
     },
     polygon: {


### PR DESCRIPTION
This PR runs the contract's tests two times:
1. Once as ran via `npx hardhat test` using the (forking) config specified in `hardhat.config.js`.
2. Once by starting a local node forked from a very recent block (head - 64 blocks).

@haurog: The changes in this fork will require removing the `ALCHEMY_POLYGON_API_KEY` variable specified your `.env` and replacing it with `POLYGON_RPC_URL` that specifies the entire RPC URL (with key), see the example `./env`file.